### PR TITLE
feat: Add frequency band selection for dynamic radius adjustment

### DIFF
--- a/src/static/css/output.css
+++ b/src/static/css/output.css
@@ -748,6 +748,10 @@ video {
   width: 100%;
 }
 
+.min-w-full {
+  min-width: 100%;
+}
+
 .max-w-sm {
   max-width: 24rem;
 }
@@ -854,6 +858,17 @@ video {
   margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
 }
 
+.divide-y > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
+}
+
+.divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-divide-opacity));
+}
+
 .rounded {
   border-radius: 0.25rem;
 }
@@ -901,6 +916,21 @@ video {
   background-color: rgb(31 41 55 / var(--tw-bg-opacity));
 }
 
+.bg-green-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(187 247 208 / var(--tw-bg-opacity));
+}
+
+.bg-orange-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 215 170 / var(--tw-bg-opacity));
+}
+
+.bg-red-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+}
+
 .bg-red-500 {
   --tw-bg-opacity: 1;
   background-color: rgb(239 68 68 / var(--tw-bg-opacity));
@@ -909,6 +939,11 @@ video {
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+}
+
+.bg-yellow-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 240 138 / var(--tw-bg-opacity));
 }
 
 .bg-opacity-50 {
@@ -1178,20 +1213,6 @@ video {
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
-.markdown-content strong {
-  font-weight: 700;
-}
-
-:is(.dark .markdown-content strong) {
-  --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity));
-}
-
-:is(.dark .markdown-content li) {
-  --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity));
-}
-
 .text-theme-responsive {
   color: black;
 }
@@ -1262,6 +1283,105 @@ video {
   transition: opacity 1s;
 }
 
+.frequency-range-legend {
+  margin-top: 1.25rem;
+  display: none;
+  border-radius: 0.375rem;
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+  padding: 1rem;
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.frequency-range-legend-header {
+  display: flex;
+  cursor: move;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem;
+}
+
+.frequency-range-legend-header button {
+  border-style: none;
+  background-color: transparent;
+}
+
+.frequency-range-legend-header button:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.frequency-table th {
+  border-bottom-width: 2px;
+  --tw-border-opacity: 1;
+  border-color: rgb(0 0 0 / var(--tw-border-opacity));
+}
+
+.frequency-table tbody tr:first-child {
+  border-top-width: 2px;
+  --tw-border-opacity: 1;
+  border-color: rgb(0 0 0 / var(--tw-border-opacity));
+}
+
+.frequency-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.frequency-table td {
+  text-align: center;
+}
+
+th[onclick] {
+  cursor: pointer;
+}
+
+th[onclick]:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(59 130 246 / var(--tw-bg-opacity));
+}
+
+:is(.dark th[onclick]:hover) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(31 41 55 / var(--tw-bg-opacity));
+}
+
+:is(.dark th[onclick]:hover:hover) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(107 114 128 / var(--tw-bg-opacity));
+}
+
+.highlighted-column {
+  --tw-bg-opacity: 1;
+  background-color: rgb(219 234 254 / var(--tw-bg-opacity));
+}
+
+:is(.dark .highlighted-column) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(156 163 175 / var(--tw-bg-opacity));
+}
+
+.frequency-table tbody tr td {
+  border-bottom-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity));
+}
+
+.frequency-table th, .frequency-table td {
+  border-left-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity));
+}
+
+.frequency-table th:last-child, .frequency-table td:last-child {
+  border-right-width: 0px;
+}
+
 .hover\:bg-blue-300:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(147 197 253 / var(--tw-bg-opacity));
@@ -1317,6 +1437,26 @@ video {
 :is(.dark .dark\:bg-gray-800) {
   --tw-bg-opacity: 1;
   background-color: rgb(31 41 55 / var(--tw-bg-opacity));
+}
+
+:is(.dark .dark\:bg-green-800) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(22 101 52 / var(--tw-bg-opacity));
+}
+
+:is(.dark .dark\:bg-orange-600) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(234 88 12 / var(--tw-bg-opacity));
+}
+
+:is(.dark .dark\:bg-red-700) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(185 28 28 / var(--tw-bg-opacity));
+}
+
+:is(.dark .dark\:bg-yellow-700) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(161 98 7 / var(--tw-bg-opacity));
 }
 
 :is(.dark .dark\:from-custom-dark-start) {

--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -67,3 +67,47 @@
 .toast-transition {
   transition: opacity 1s;
 }
+
+.frequency-range-legend {
+  @apply bg-white border border-gray-300 rounded-md p-4 shadow-md mt-5 hidden;
+}
+
+.frequency-table th {
+  @apply border-b-2 border-black;
+}
+
+.frequency-table tbody tr:first-child {
+  @apply border-t-2 border-black;
+}
+
+.frequency-table {
+  @apply w-full border-collapse;
+}
+
+.frequency-table td {
+  @apply text-center;
+}
+
+th[onclick] {
+  @apply cursor-pointer;
+}
+
+th[onclick]:hover {
+  @apply bg-blue-500 dark:bg-gray-800 dark:hover:bg-gray-500;
+}
+
+.highlighted-column {
+  @apply bg-blue-100 dark:bg-gray-400;
+}
+
+.frequency-table tbody tr td {
+  @apply border-b border-gray-300;
+}
+
+.frequency-table th, .frequency-table td {
+  @apply border-l border-gray-300;
+}
+
+.frequency-table th:last-child, .frequency-table td:last-child {
+  @apply border-r-0;
+}

--- a/src/static/scripts/pages/ui-interactions.js
+++ b/src/static/scripts/pages/ui-interactions.js
@@ -673,6 +673,8 @@ document.addEventListener('click', function(event) {
 function addRing(lat, lng, radius, color) {
     L.circle([lat, lng], {
         color: color,
+        fillColor: color,
+        fillOpacity: 0, 
         radius: radius
     }).addTo(mymap);
 }

--- a/src/static/scripts/pages/ui-interactions.js
+++ b/src/static/scripts/pages/ui-interactions.js
@@ -312,6 +312,7 @@ function sendLocation(lat, lng, limit = 9, max_distance = null) {
             updateBTSCount(data.count);
             showSidebar(); 
             displayStations(data.stations);
+            addRingsForLocation(lat,lng);
         }
     })
 }
@@ -336,6 +337,7 @@ function clearStationMarkers() { // clearing markers when new location is submit
 
 function displayStations(data) {
     clearStationMarkers(); // Clear existing markers
+    clearRings();
     let sidebarContent = document.getElementById('sidebar');
     sidebarContent.innerHTML = ''; // Clear existing sidebar content
     let stations;
@@ -472,6 +474,7 @@ function fetchStations() {
         updateBTSCount(data.count);
         showSidebar();
         displayStations(data.stations);
+        addRingsForLocation(currentFilters.lat, currentFilters.lng);
     })
 }
 
@@ -666,3 +669,25 @@ document.addEventListener('click', function(event) {
         updateStationFilters();
     }
 });
+
+function addRing(lat, lng, radius, color) {
+    L.circle([lat, lng], {
+        color: color,
+        radius: radius
+    }).addTo(mymap);
+}
+
+function addRingsForLocation(lat, lng) {
+    addRing(lat, lng, 1000, 'green'); // 1km
+    addRing(lat, lng, 2000, 'yellow');
+    addRing(lat, lng, 4000, 'red'); 
+}
+
+function clearRings() {
+    mymap.eachLayer(function(layer) {
+        if (layer instanceof L.Circle) {
+            mymap.removeLayer(layer);
+        }
+    });
+}
+


### PR DESCRIPTION
Key Features:
- Interactive buttons within the frequency table header allow for easy switching between frequency bands
- The selection triggers an update to the map, where rings are redrawn based on the new radius values specific to the selected band
- Initial setup defaults to the 'low' band frequency, ensuring a consistent starting point for users

This enhancement aims to improve user engagement by allowing for a more interactive and informative map experience, where users can visualize the impact of different frequency bands on coverage areas.