### PR TITLE
feat: Add color indicators for frequency quality in tooltip marker content

### DIFF
--- a/src/static/css/output.css
+++ b/src/static/css/output.css
@@ -1365,11 +1365,11 @@ th[onclick]:hover {
 }
 
 .text-yellow-500 {
-  color: #fcd34d;
+  color: #f59e0b;
 }
 
 .text-orange-500 {
-  color: #fb923c;
+  color: #f97316;
 }
 
 .hover\:bg-blue-300:hover {

--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -112,5 +112,5 @@ th[onclick]:hover {
   @apply border-r-0;
 }
 
-.text-yellow-500 { color: #fcd34d; } 
-.text-orange-500 { color: #fb923c; } 
+.text-yellow-500 { color: #f59e0b; } 
+.text-orange-500 { color: #f97316; } 


### PR DESCRIPTION
This update adds a new feature that helps users easily see if a frequency is good or not by using colors (green, yellow, orange, red). Now, users can quickly tell the quality of each frequency without needing to understand complex details. This change makes our app easier to use and helps users make better choices faster.