### PR TITLE
Refine logic in querying base stations via filters only without initially submitted location

### DIFF
--- a/src/queries.py
+++ b/src/queries.py
@@ -38,7 +38,7 @@ def get_latitude_segment(latitude):
     segment_size = 0.3  # Size of each latitude segment // 33.333 km
     return int((latitude - base_latitude) / segment_size)
 
-def find_nearest_stations(user_lat, user_lon, limit=9, max_distance=None, service_providers=[], frequency_bands=[]):
+def find_nearest_stations(user_lat, user_lng, limit=9, max_distance=None, service_providers=[], frequency_bands=[]):
     user_segment = get_latitude_segment(user_lat)
     adjacent_segments = [user_segment - 1, user_segment, user_segment + 1]  # Include boundary segments
 
@@ -59,7 +59,7 @@ def find_nearest_stations(user_lat, user_lon, limit=9, max_distance=None, servic
 
         # Combine filtering by max_distance and grouping into a single loop
         for station in filtered_stations:
-            distance = haversine(user_lat, user_lon, station.latitude, station.longitude)
+            distance = haversine(user_lat, user_lng, station.latitude, station.longitude)
             
             if max_distance is not None and distance > max_distance:
                 continue  # Skip this station if it's beyond the max_distance

--- a/src/static/scripts/pages/ui-interactions.js
+++ b/src/static/scripts/pages/ui-interactions.js
@@ -24,8 +24,8 @@ const providerColors = {
 };
 
 const initialFilters = () => ({
-    lat: null,
-    lng: null,
+    lat: 52.231,
+    lng: 21.004,
     limit: null,
     maxDistance: null,
     serviceProvider: [],
@@ -544,9 +544,10 @@ function createSidebarContent(station, index) {
 function constructFilterURL() {
     let params = new URLSearchParams();
 
-    const lat = currentFilters.lat !== undefined ? currentFilters.lat : mymap.getCenter().lat;
-    const lng = currentFilters.lng !== undefined ? currentFilters.lng : mymap.getCenter().lng;
-    
+    const center = mymap.getCenter();
+    currentFilters.lat = center.lat;
+    currentFilters.lng = center.lng;
+
     params.append('lat', currentFilters.lat);
     params.append('lng', currentFilters.lng);
 
@@ -574,7 +575,7 @@ function fetchStations() {
         updateBTSCount(data.count);
         showSidebar();
         displayStations(data.stations);
-        addRingsForLocation(currentFilters.lat, currentFilters.lng, currentBand);
+        addRingsForLocation(currentFilters.lat, currentFilters.lng);
         applyFrequencyColors();
     })
 }


### PR DESCRIPTION
- Refine logic in querying base stations via filters only without  initially submitted location in ui-interactions
- Refactor: change from user_lon to proper one - user_lng in queries