### PR TITLE
Refine logic in show nearest BTS & show BTSs within distance

### DIFF
--- a/src/static/scripts/pages/ui-interactions.js
+++ b/src/static/scripts/pages/ui-interactions.js
@@ -324,12 +324,22 @@ setTimeout(() => {
     document.getElementById('showNearestBtn').addEventListener('click', function() {
         currentFilters.mode = 'nearest';
         currentFilters.limit = nearestBtsRange.value;
+        if (!locationSetInitially) {
+            const center = mymap.getCenter();
+            currentFilters.lat = center.lat;
+            currentFilters.lng = center.lng;
+        }
         fetchStations();
     });
 
     document.getElementById('showWithinDistanceBtn').addEventListener('click', function() {
         currentFilters.mode = 'withinDistance';
         currentFilters.maxDistance = withinDistanceRange.value;
+        if (!locationSetInitially) {
+            const center = mymap.getCenter();
+            currentFilters.lat = center.lat;
+            currentFilters.lng = center.lng;
+        }
         fetchStations();
     });
 }, 0);


### PR DESCRIPTION
This commit ensures smoother experience when user does not initially submit location, uses _show nearest BTS_ & _show BTS within distance_ from filtering container. The latitude and longitude will be taken from mymap.getCenter() position 