### PR TITLE
Enhance: fix Show BTS within distance query, parameter validation, refactor code, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Signal-Scout 
 
-Signal-Scout is a web application designed to help users find the nearest base stations for various service providers, ensuring optimal signal strength for mobile devices. This application is particularly useful for travelers or anyone needing to stay connected in different locations.
+[Signal-Scout](https://www.signal-scout.com) is a web application designed to help users find the nearest base stations for various service providers, ensuring optimal signal strength for mobile devices. This application is particularly useful for travelers or anyone needing to stay connected in different locations.
 
 ## Features
 

--- a/src/app.py
+++ b/src/app.py
@@ -162,6 +162,17 @@ def get_stations():
 
         max_distance = request.args.get('max_distance', default=None, type=float)
         limit = request.args.get('limit', default=9, type=int)
+
+        if max_distance is not None:
+            if max_distance < 0.1 or max_distance > 10:
+                return jsonify({"error": "Invalid parameter", "message": "Max distance must be between 0.1 and 10 km. Please respect it."}), 400
+            # Set limit to None when a valid max_distance is provided to focus on distance-based filtering
+            limit = None
+        elif limit is not None:
+            # Validate limit if max_distance is not provided
+            if limit < 1 or limit > 10:
+                return jsonify({"error": "Invalid parameter", "message": "Limit cannot exceed 10. Please respect it."}), 400
+
         frequency_bands = request.args.getlist('frequency_bands')
         raw_service_providers = request.args.getlist('service_provider')
 

--- a/src/queries.py
+++ b/src/queries.py
@@ -38,7 +38,7 @@ def get_latitude_segment(latitude):
     segment_size = 0.3  # Size of each latitude segment // 33.333 km
     return int((latitude - base_latitude) / segment_size)
 
-def find_nearest_stations(user_lat, user_lng, limit=9, max_distance=None, service_providers=[], frequency_bands=[]):
+def find_nearest_stations(user_lat, user_lng, limit=None, max_distance=None, service_providers=[], frequency_bands=[]):
     user_segment = get_latitude_segment(user_lat)
     adjacent_segments = [user_segment - 1, user_segment, user_segment + 1]  # Include boundary segments
 
@@ -53,7 +53,6 @@ def find_nearest_stations(user_lat, user_lng, limit=9, max_distance=None, servic
         
         # Execute the filtered query
         filtered_stations = query.all()
-
         # Initialize a dictionary to hold the grouped stations with aggregated frequency bands
         grouped_stations = {}
 
@@ -67,7 +66,6 @@ def find_nearest_stations(user_lat, user_lng, limit=9, max_distance=None, servic
             # Key for grouping stations by their unique location
             key = (station.latitude, station.longitude)
             distance_rounded = round(distance, 2)
-            
             # Aggregate frequency bands and update distance if necessary
             if key not in grouped_stations:
                 grouped_stations[key] = {
@@ -92,13 +90,10 @@ def find_nearest_stations(user_lat, user_lng, limit=9, max_distance=None, servic
             sorted_bands = sort_frequency_bands(station_info['frequency_bands'])
             station_info['frequency_bands'] = sorted_bands
 
-        final_stations_list = sorted(grouped_stations.values(), key=lambda x: x['distance'])
-
         # Prepare the final list of stations, applying the limit
         final_stations_list = sorted(grouped_stations.values(), key=lambda x: x['distance'])
         if limit is not None:
             final_stations_list = final_stations_list[:limit]
-
         # Convert frequency_bands sets to lists for JSON serialization
         for station_info in final_stations_list:
             station_info['frequency_bands'] = list(station_info['frequency_bands'])


### PR DESCRIPTION
**Fix Show BTS within distance query in app.py**
- When a valid `max_distance` is provided, `limit` is automatically set to None. This prioritizes distance-based queries, facilitating a broader overview of base stations within a specified range 

**Parameter validation in app.py**

Added validation checks to ensure:
  - `max_distance` falls within 0.1 to 10 km, 
  - `limit` does not exceed 10, 
 
preventing unrealistic range queries that could affect performance / exploit app and the responses are within expected data thresholds.

**Refactor code in queries.py** 

- remove redundant duplicate line that sorted `final_stations_list`

**Update README**

- add application URL
